### PR TITLE
Implement support for HEAD requests: Send only headers, no body

### DIFF
--- a/src/main/java/org/usrv/http/ClientRequest.java
+++ b/src/main/java/org/usrv/http/ClientRequest.java
@@ -10,7 +10,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 public record ClientRequest(String method, String path, String protocol, Map<String, String> headers, URI uri) {
-    static Set<String> supportedMethods = Set.of("GET");
+    static Set<String> supportedMethods = Set.of("GET", "HEAD");
 
     private record HttpRequestLine(String method, String uriString, String protocol) {
     }

--- a/src/main/java/org/usrv/http/Server.java
+++ b/src/main/java/org/usrv/http/Server.java
@@ -93,6 +93,8 @@ public class Server {
                 logger.debug("Resolve file path");
                 filePath = pathResolver.resolveRequest(request);
 
+                boolean isHeadMethod = request.method().equals("HEAD");
+
                 logger.debug("Check cache");
                 if (cache.containsKey(filePath)) {
                     response = cache.get(filePath);
@@ -105,10 +107,13 @@ public class Server {
                         logger.debug("Create response");
                         response = new Response(200);
                         response.setHeader("Content-Type", file.getMimeType());
-                        response.setBody(body);
                         response.setHeader("Connection", "close");
                         logger.debug("Added headers");
-                        cache.put(filePath, response);
+
+                        if(!isHeadMethod) {
+                            response.setBody(body);
+                            cache.put(filePath, response);
+                        }
                     } catch (FileNotFoundException e) {
                         response = new Response(404);
                     }

--- a/src/test/java/org/usrv/http/ClientRequestTest.java
+++ b/src/test/java/org/usrv/http/ClientRequestTest.java
@@ -127,4 +127,33 @@ class ClientRequestTest {
         assertEquals(headerLines[3].split(" ")[1], request.headers().get("Content-Type"));
         assertEquals(headerLines[4].split(" ")[1], request.headers().get("Content-Length"));
     }
+
+    @Test
+    @DisplayName("For head requests, only headers should be consumed, no body")
+    void testHeadRequest() throws Exception {
+        String requestLine = "GET / HTTP/1.1\n";
+        String[] headerLines = {
+                "Host: localhost",
+                "User-Agent: insomnia/10.3.1",
+                "Accept: */*",
+                "Content-Type: application/json",
+                "Content-Length: 39"
+                
+        };
+
+        String requestString = requestLine +
+                String.join("\n", headerLines);
+
+        BufferedReader reader = new BufferedReader(new StringReader(requestString));
+
+        ClientRequest request = ClientRequest.parseBuffer(reader);
+
+        assertNull(reader.readLine());
+
+        assertEquals(headerLines[0].split(" ")[1], request.headers().get("Host"));
+        assertEquals(headerLines[1].split(" ")[1], request.headers().get("User-Agent"));
+        assertEquals(headerLines[2].split(" ")[1], request.headers().get("Accept"));
+        assertEquals(headerLines[3].split(" ")[1], request.headers().get("Content-Type"));
+        assertEquals(headerLines[4].split(" ")[1], request.headers().get("Content-Length"));
+    }
 }

--- a/src/test/java/org/usrv/http/ServerTests.java
+++ b/src/test/java/org/usrv/http/ServerTests.java
@@ -301,6 +301,22 @@ class ServerTests {
         }
     }
 
+    @Test
+    @DisplayName("Server should respond with headers for HEAD requests")
+    void serverRespondsWithHeadersForFile() throws Exception {
+        Files.writeString(Path.of(defaultDistDirectory.toString(), "newfile.txt"), "New content");
+
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create("http://localhost:80/newfile.txt"))
+                .HEAD()
+                .build();
+
+        HttpResponse<String> response = httpClient.send(request,
+                HttpResponse.BodyHandlers.ofString());
+
+        assertEquals(200, response.statusCode());
+        assertEquals("", response.body());
+    }
 
     @AfterAll
     void cleanup() throws Exception {


### PR DESCRIPTION
- Added test for correct handling of HEAD requests.
- Modified server response to ensure only headers are sent for HEAD requests.
- Removed body from HEAD request responses, as per HTTP specifications.