### PR TITLE
Require host header

### DIFF
--- a/src/main/java/org/usrv/exceptions/InvalidRequestException.java
+++ b/src/main/java/org/usrv/exceptions/InvalidRequestException.java
@@ -1,6 +1,7 @@
 package org.usrv.exceptions;
 
 public class InvalidRequestException extends RuntimeException {
+    public static final String MISSING_REQUIRED_HOST_MESSAGE = "Missing required Host header";
     public InvalidRequestException(String message) {
         super(message);
     }

--- a/src/main/java/org/usrv/http/ClientRequest.java
+++ b/src/main/java/org/usrv/http/ClientRequest.java
@@ -91,6 +91,8 @@ public record ClientRequest(String method, String path, String protocol, Map<Str
     }
 
     private boolean isHostRequiredForProtocol(){
-        return Objects.equals(this.protocol, "HTTP/1.1");
+        Set<String> protocolsWithRequiredHost = Set.of("HTTP/1.1", "HTTP/2", "HTTP/3");
+
+        return protocolsWithRequiredHost.contains(this.protocol);
     }
 }

--- a/src/main/java/org/usrv/http/ClientRequest.java
+++ b/src/main/java/org/usrv/http/ClientRequest.java
@@ -15,8 +15,6 @@ public record ClientRequest(String method, String path, String protocol, Map<Str
     private record HttpRequestLine(String method, String uriString, String protocol) {
     }
 
-    ;
-
     public static ClientRequest parse(String request) {
         try {
             String[] requestLines = request.split("\n");
@@ -87,6 +85,12 @@ public record ClientRequest(String method, String path, String protocol, Map<Str
             throw new InvalidRequestException("Unsupported method: " + this.method);
         } else if (!Objects.equals(this.protocol, "HTTP/1.1")) {
             throw new InvalidRequestException("Unsupported protocol: " + this.protocol);
+        } else if(this.isHostRequiredForProtocol() && !this.headers.containsKey("Host")) {
+            throw new InvalidRequestException(InvalidRequestException.MISSING_REQUIRED_HOST_MESSAGE);
         }
+    }
+
+    private boolean isHostRequiredForProtocol(){
+        return Objects.equals(this.protocol, "HTTP/1.1");
     }
 }

--- a/src/main/java/org/usrv/http/Server.java
+++ b/src/main/java/org/usrv/http/Server.java
@@ -7,6 +7,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 import org.usrv.config.ServerConfig;
+import org.usrv.exceptions.InvalidRequestException;
 import org.usrv.file.PathResolver;
 import org.usrv.file.StaticFile;
 import org.usrv.exceptions.RequestParsingException;
@@ -79,7 +80,7 @@ public class Server {
         try (
                 socket;
                 BufferedReader in = new BufferedReader(new InputStreamReader(socket.getInputStream()));
-                PrintWriter out = new PrintWriter(socket.getOutputStream(), true);
+                PrintWriter out = new PrintWriter(socket.getOutputStream(), true)
         ) {
             Response response;
             Path filePath = null;
@@ -89,6 +90,9 @@ public class Server {
             try {
                 logger.debug("Parse request");
                 request = ClientRequest.parseBuffer(in);
+
+                logger.debug("Validate request");
+                request.validate();
 
                 logger.debug("Resolve file path");
                 filePath = pathResolver.resolveRequest(request);
@@ -113,7 +117,7 @@ public class Server {
                         response = new Response(404);
                     }
                 }
-            } catch (RequestParsingException e) {
+            } catch (RequestParsingException | InvalidRequestException e) {
                 response = new Response(400);
             }
 

--- a/src/test/java/org/usrv/http/ClientRequestTest.java
+++ b/src/test/java/org/usrv/http/ClientRequestTest.java
@@ -1,14 +1,15 @@
 package org.usrv.http;
 
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.usrv.exceptions.InvalidRequestException;
 import org.usrv.exceptions.RequestParsingException;
-
-import java.io.*;
-import java.util.Map;
-
-import static org.junit.jupiter.api.Assertions.*;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
+import java.io.BufferedReader;
+import java.io.StringReader;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class ClientRequestTest {
@@ -90,6 +91,24 @@ class ClientRequestTest {
         Exception exception = assertThrows(RequestParsingException.class, () -> ClientRequest.parseBuffer(reader));
 
         assertEquals("Failed to parse request line: ", exception.getMessage());
+    }
+
+
+    @Test
+    @DisplayName("It should throw an error upon validating a request that is missing host")
+    void testValidateRequestWithMissingHost() {
+        String requestString = """
+                GET / HTTP/1.1
+                User-Agent: insomnia/10.3.1
+                Accept: */*
+                """;
+
+        BufferedReader reader = new BufferedReader(new StringReader(requestString));
+
+        ClientRequest request = ClientRequest.parseBuffer(reader);
+        Exception exception = assertThrows(InvalidRequestException.class, request::validate);
+
+        assertEquals(InvalidRequestException.MISSING_REQUIRED_HOST_MESSAGE, exception.getMessage());
     }
 
 

--- a/src/test/java/org/usrv/http/ServerTests.java
+++ b/src/test/java/org/usrv/http/ServerTests.java
@@ -178,13 +178,11 @@ class ServerTests {
              PrintWriter out = new PrintWriter(socket.getOutputStream(), true);
              BufferedReader in = new BufferedReader(new InputStreamReader(socket.getInputStream()))) {
 
-            // Send a malformed request
             out.println("GET / HTTP/1.1");
             out.println("User-Agent: insomnia/10.3.1\n");
-            out.println("Accept: */*\n");  // Missing path and HTTP version
+            out.println("Accept: */*\n");
             out.flush();
 
-            // Read and print the response
             ArrayList<String> lines = new ArrayList<>();
             String line;
 

--- a/src/test/java/org/usrv/http/ServerTests.java
+++ b/src/test/java/org/usrv/http/ServerTests.java
@@ -172,6 +172,31 @@ class ServerTests {
     }
 
     @Test
+    @DisplayName("Server responds with a 400 status if the request is missing host for HTTP 1.1")
+    void serverRespondsWith400WhenMissingHost() throws Exception {
+        try (Socket socket = new Socket("localhost", 80);
+             PrintWriter out = new PrintWriter(socket.getOutputStream(), true);
+             BufferedReader in = new BufferedReader(new InputStreamReader(socket.getInputStream()))) {
+
+            // Send a malformed request
+            out.println("GET / HTTP/1.1");
+            out.println("User-Agent: insomnia/10.3.1\n");
+            out.println("Accept: */*\n");  // Missing path and HTTP version
+            out.flush();
+
+            // Read and print the response
+            ArrayList<String> lines = new ArrayList<>();
+            String line;
+
+            while ((line = in.readLine()) != null && !line.isEmpty()) {
+                lines.add(line);
+            }
+
+            assertEquals("HTTP/1.1 400 Bad Request", lines.getFirst());
+        }
+    }
+
+    @Test
     @DisplayName("Server uses cached response for subsequent requests")
     void serverUsesCachedResponse() throws Exception {
         Path path = Path.of("./TEST_DIST/dist/index.html");


### PR DESCRIPTION
Require host header for HTTP/1.1 requests. 

Let''s discuss whether this should be checked in the validate() method or somewhere else.
Imo it's not a parsing error but actually an invalid request, what do you think?

Also, I'm not sure if the server test is the way to go. I just copied the test above that had a similar use case...