### PR TITLE
Add load testing

### DIFF
--- a/scripts/load-test.sh
+++ b/scripts/load-test.sh
@@ -1,0 +1,12 @@
+## Load tests
+#
+# Load tests are run using siege
+#
+# Link: https://www.joedog.org/siege-home/
+# Installation with homebrew: https://formulae.brew.sh/formula/siege
+# Or download from: http://download.joedog.org/siege/siege-latest.tar.gz
+#
+# To change what urls are used, edit ./siege/etc/urls.txt
+
+# Runs siege with 25 workers, a randomized delay of around 0.3s and 100 repetitions per worker
+siege -c25 -d0.3 -r100 --file=./siege/etc/urls.txt

--- a/scripts/siege/etc/urls.txt
+++ b/scripts/siege/etc/urls.txt
@@ -1,0 +1,4 @@
+http://localhost:80/
+http://localhost:80/assets/index-FZLPApSI.js
+http://localhost:80/assets/index-C-E0oYUp.css
+http://localhost:80/assets/demo_image.webp

--- a/src/main/java/org/usrv/Main.java
+++ b/src/main/java/org/usrv/Main.java
@@ -5,7 +5,7 @@ import org.usrv.http.Server;
 
 public class Main {
     public static void main(String[] args) {
-        Server server = new Server(new ServerConfig("./dist", 80, true));
+        Server server = new Server(new ServerConfig("./dist", 80, false));
         server.start();
     }
 }


### PR DESCRIPTION
Adds a short shell script/command for running load testing via siege. You can edit the urls.txt for your own needs based on what you have in the /dist folder (which the server serves from by default).

I opted to have urls.txt source controlled even though it's just my own urls in there so that others can use as an example. We may want to make it more generic in the future.